### PR TITLE
Fix capitalisation of "AppKit" in pod spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os:
   - osx
 language: swift
-osx_image: xcode9
+osx_image: xcode10.1
 script:
   - swift build
   - swift test

--- a/HotKey.podspec
+++ b/HotKey.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |spec|
 
   spec.osx.deployment_target = '10.9'
 
-  spec.frameworks = 'Appkit', 'Carbon'
+  spec.frameworks = 'AppKit', 'Carbon'
   spec.source_files = 'Sources/HotKey/**/*.{h,m,swift}'
 end


### PR DESCRIPTION
This should never have worked in the first place, but it's apparently causing issues for users with case-sensitive filesystems (bellebethcooper/cashew#63).