### PR TITLE
Add aliases for bracket/grave keys

### DIFF
--- a/Sources/HotKey/Key.swift
+++ b/Sources/HotKey/Key.swift
@@ -154,10 +154,10 @@ public enum Key {
 		case "minus", "-": self = .minus
 		case "eight", "8": self = .eight
 		case "zero", "0": self = .zero
-		case "rightBracket": self = .rightBracket
+		case "rightBracket", "]": self = .rightBracket
 		case "o": self = .o
 		case "u": self = .u
-		case "leftBracket": self = .leftBracket
+		case "leftBracket", "[": self = .leftBracket
 		case "i": self = .i
 		case "p": self = .p
 		case "l": self = .l
@@ -171,7 +171,7 @@ public enum Key {
 		case "n": self = .n
 		case "m": self = .m
 		case "period", ".": self = .period
-		case "grave": self = .grave
+		case "grave", "`": self = .grave
 		case "keypaddecimal": self = .keypadDecimal
 		case "keypadmultiply": self = .keypadMultiply
 		case "keypadplus": self = .keypadPlus


### PR DESCRIPTION
Thank you for an amazing library!

This is just a simple PR which adds a couple of aliases for constructing `Key` from string:

* alias _grave_ to _`_
* alias _leftbracket_ to _[_
* alias _rightbracket_ to _]_