### PR TITLE
Fix unused setter argument warning

### DIFF
--- a/Sources/HotKey/KeyCombo.swift
+++ b/Sources/HotKey/KeyCombo.swift
@@ -23,7 +23,7 @@ public struct KeyCombo: Equatable {
 		}
 
 		set {
-			carbonModifiers = modifiers.carbonFlags
+			carbonModifiers = newValue.carbonFlags
 		}
 	}
 


### PR DESCRIPTION
Fixes:
```
Sources/HotKey/KeyCombo.swift:26:22: warning: setter argument 'newValue' was never used, but the property was accessed
                        carbonModifiers = modifiers.carbonFlags
                                          ^
Sources/HotKey/KeyCombo.swift:26:22: note: did you mean to use 'newValue' instead of accessing the property's current value?
                        carbonModifiers = modifiers.carbonFlags
                                          ^~~~~~~~~
                                          newValue
```
