### PR TITLE
Allow SwiftUI to Build Previews in Mixed Platform Projects

### DIFF
--- a/Sources/HotKey/HotKey.swift
+++ b/Sources/HotKey/HotKey.swift
@@ -1,3 +1,4 @@
+#if canImport(AppKit) && canImport(Carbon)
 import AppKit
 import Carbon
 
@@ -48,3 +49,4 @@ public final class HotKey {
 		HotKeysController.unregister(self)
 	}
 }
+#endif  // canImport(AppKit) && canImport(Carbon)

--- a/Sources/HotKey/HotKey.swift
+++ b/Sources/HotKey/HotKey.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit) && canImport(Carbon)
+#if !targetEnvironment(macCatalyst) && canImport(AppKit) && canImport(Carbon)
 import AppKit
 import Carbon
 
@@ -49,4 +49,4 @@ public final class HotKey {
 		HotKeysController.unregister(self)
 	}
 }
-#endif  // canImport(AppKit) && canImport(Carbon)
+#endif  // !targetEnvironment(macCatalyst) && canImport(AppKit) && canImport(Carbon)

--- a/Sources/HotKey/HotKeysController.swift
+++ b/Sources/HotKey/HotKeysController.swift
@@ -1,3 +1,4 @@
+#if canImport(Carbon)
 import Carbon
 
 final class HotKeysController {
@@ -183,3 +184,5 @@ final class HotKeysController {
 private func hotKeyEventHandler(eventHandlerCall: EventHandlerCallRef?, event: EventRef?, userData: UnsafeMutableRawPointer?) -> OSStatus {
 	return HotKeysController.handleCarbonEvent(event)
 }
+
+#endif  // canImport(Carbon)

--- a/Sources/HotKey/HotKeysController.swift
+++ b/Sources/HotKey/HotKeysController.swift
@@ -1,4 +1,4 @@
-#if canImport(Carbon)
+#if !targetEnvironment(macCatalyst) && canImport(Carbon)
 import Carbon
 
 final class HotKeysController {
@@ -185,4 +185,4 @@ private func hotKeyEventHandler(eventHandlerCall: EventHandlerCallRef?, event: E
 	return HotKeysController.handleCarbonEvent(event)
 }
 
-#endif  // canImport(Carbon)
+#endif  // !targetEnvironment(macCatalyst) && canImport(Carbon)

--- a/Sources/HotKey/Key.swift
+++ b/Sources/HotKey/Key.swift
@@ -1,3 +1,4 @@
+#if canImport(Carbon)
 import Carbon
 
 public enum Key {
@@ -606,3 +607,4 @@ extension Key: CustomStringConvertible {
         }
     }
 }
+#endif  // canImport(Carbon)

--- a/Sources/HotKey/Key.swift
+++ b/Sources/HotKey/Key.swift
@@ -1,4 +1,4 @@
-#if canImport(Carbon)
+#if !targetEnvironment(macCatalyst) && canImport(Carbon)
 import Carbon
 
 public enum Key {
@@ -607,4 +607,4 @@ extension Key: CustomStringConvertible {
         }
     }
 }
-#endif  // canImport(Carbon)
+#endif  // !targetEnvironment(macCatalyst) && canImport(Carbon)

--- a/Sources/HotKey/KeyCombo+System.swift
+++ b/Sources/HotKey/KeyCombo+System.swift
@@ -1,3 +1,4 @@
+#if canImport(AppKit) && canImport(Carbon)
 import AppKit
 import Carbon
 
@@ -129,3 +130,4 @@ extension KeyCombo {
         ]
     }
 }
+#endif  // canImport(AppKit) && canImport(Carbon)

--- a/Sources/HotKey/KeyCombo+System.swift
+++ b/Sources/HotKey/KeyCombo+System.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit) && canImport(Carbon)
+#if !targetEnvironment(macCatalyst) && canImport(AppKit) && canImport(Carbon)
 import AppKit
 import Carbon
 
@@ -130,4 +130,4 @@ extension KeyCombo {
         ]
     }
 }
-#endif  // canImport(AppKit) && canImport(Carbon)
+#endif  // !targetEnvironment(macCatalyst) && canImport(AppKit) && canImport(Carbon)

--- a/Sources/HotKey/KeyCombo.swift
+++ b/Sources/HotKey/KeyCombo.swift
@@ -1,3 +1,4 @@
+#if canImport(AppKit)
 import AppKit
 
 public struct KeyCombo: Equatable {
@@ -80,3 +81,4 @@ extension KeyCombo: CustomStringConvertible {
         return output
     }
 }
+#endif  // canImport(AppKit)

--- a/Sources/HotKey/KeyCombo.swift
+++ b/Sources/HotKey/KeyCombo.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit)
+#if !targetEnvironment(macCatalyst) && canImport(AppKit)
 import AppKit
 
 public struct KeyCombo: Equatable {
@@ -81,4 +81,4 @@ extension KeyCombo: CustomStringConvertible {
         return output
     }
 }
-#endif  // canImport(AppKit)
+#endif  // !targetEnvironment(macCatalyst) && canImport(AppKit)

--- a/Sources/HotKey/NSEventModifierFlags+HotKey.swift
+++ b/Sources/HotKey/NSEventModifierFlags+HotKey.swift
@@ -1,4 +1,4 @@
-#if canImport(AppKit) && canImport(Carbon)
+#if !targetEnvironment(macCatalyst) && canImport(AppKit) && canImport(Carbon)
 import AppKit
 import Carbon
 
@@ -69,4 +69,4 @@ extension NSEvent.ModifierFlags: CustomStringConvertible {
         return output
     }
 }
-#endif // canImport(AppKit) && canImport(Carbon)
+#endif // !targetEnvironment(macCatalyst) && canImport(AppKit) && canImport(Carbon)

--- a/Sources/HotKey/NSEventModifierFlags+HotKey.swift
+++ b/Sources/HotKey/NSEventModifierFlags+HotKey.swift
@@ -1,3 +1,4 @@
+#if canImport(AppKit) && canImport(Carbon)
 import AppKit
 import Carbon
 
@@ -68,3 +69,4 @@ extension NSEvent.ModifierFlags: CustomStringConvertible {
         return output
     }
 }
+#endif // canImport(AppKit) && canImport(Carbon)


### PR DESCRIPTION
SwiftUI tries to build every SwiftPackage when generating a preview. If there are packages for a platform it does not support, previews do not build. This can happen when a project targets both Mac and iOS.